### PR TITLE
switched desktop client host url to https and wss

### DIFF
--- a/Client/src/main/java/gamesuite/client/control/ClientManager.java
+++ b/Client/src/main/java/gamesuite/client/control/ClientManager.java
@@ -32,8 +32,8 @@ public class ClientManager {
     private GUIManager guiGM;
     
     public ClientManager(String ip, int port) {
-        this.baseUrl = "http://" + ip + ":" + port;
-        this.wsUrl = "ws://" + ip + ":" + port + "/ingame";
+        this.baseUrl = "https://" + ip + ":" + port;
+        this.wsUrl = "wss://" + ip + ":" + port + "/ingame";
         restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
     }
 


### PR DESCRIPTION
The desktop client was updated to send requests over https and wss. I purchased a domain name and set up ssl key and certificate. nginx is now being used as a reverse proxy to and decrypts and sends to spring boot server which is still configured for http/ws on port 8080.